### PR TITLE
fix: should use context.factory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,9 @@ function createDistAst(context: ts.TransformationContext, struct: ImportedStruct
       undefined,
       context.factory.createImportClause(
         false,
-        struct.variableName || !options.transformToDefaultImport ? undefined : ts.createIdentifier(struct.importName),
+        struct.variableName || !options.transformToDefaultImport
+          ? undefined
+          : context.factory.createIdentifier(struct.importName),
         struct.variableName
           ? context.factory.createNamedImports([
               context.factory.createImportSpecifier(


### PR DESCRIPTION
fix for warning in ts@4.8.3: DeprecationWarning: 'createIdentifier' has been deprecated since v4.0.0. Use the appropriate method on 'ts.factory' or the 'factory' supplied by your transformation context instead.
DeprecationWarning: 'createIdentifier' has been deprecated since v4.0.0. Use the appropriate method on 'ts.factory' or the 'factory' supplied by your transformation context instead.